### PR TITLE
[VIVS] Remove unnecessary result return types

### DIFF
--- a/cargo-projects/vivs/src/commands.rs
+++ b/cargo-projects/vivs/src/commands.rs
@@ -1,5 +1,5 @@
 use crate::data_chunk::{DataChunkError, DataChunkFrame};
-use crate::utils::{format_err_msg, unknown_cmd_err};
+use crate::utils::unknown_cmd_err;
 use crate::{Connection, DataStoreWrapper, Error, Result};
 use delete::Delete;
 use get::Get;

--- a/cargo-projects/vivs/src/commands/delete.rs
+++ b/cargo-projects/vivs/src/commands/delete.rs
@@ -8,12 +8,12 @@ pub struct Delete {
 }
 
 impl Delete {
-    pub fn parse(mut data: DataChunkFrame) -> Result<Self> {
+    pub fn parse(mut data: DataChunkFrame) -> Self {
         let Ok(key) = data.next_as_str() else {
-            return Ok(Self { key: None });
+            return Self { key: None };
         };
 
-        Ok(Self { key: Some(key) })
+        Self { key }
     }
 
     pub async fn respond(self, conn: &mut Connection, db: &DataStoreWrapper) -> Result<()> {

--- a/cargo-projects/vivs/src/commands/get.rs
+++ b/cargo-projects/vivs/src/commands/get.rs
@@ -12,7 +12,6 @@ pub struct Get {
 impl Get {
     pub fn parse(mut data: DataChunkFrame) -> Self {
         let Ok(key) = data.next_as_str() else {
-            // Setting key to None here will write error message to tcp stream
             return Self { key: None };
         };
 

--- a/cargo-projects/vivs/src/commands/get.rs
+++ b/cargo-projects/vivs/src/commands/get.rs
@@ -10,13 +10,13 @@ pub struct Get {
 }
 
 impl Get {
-    pub fn parse(mut data: DataChunkFrame) -> Result<Self> {
+    pub fn parse(mut data: DataChunkFrame) -> Self {
         let Ok(key) = data.next_as_str() else {
-            // Setting key to None will force error message to be written back to tcp stream
-            return Ok(Self { key: None });
+            // Setting key to None here will write error message to tcp stream
+            return Self { key: None };
         };
 
-        Ok(Self { key: Some(key) })
+        Self { key }
     }
 
     pub async fn respond(&self, conn: &mut Connection, db: &DataStoreWrapper) -> Result<()> {

--- a/cargo-projects/vivs/src/commands/ping.rs
+++ b/cargo-projects/vivs/src/commands/ping.rs
@@ -15,10 +15,10 @@ impl Ping {
         Ping { message }
     }
 
-    pub fn parse(mut data: DataChunkFrame) -> Result<Self> {
+    pub fn parse(mut data: DataChunkFrame) -> Self {
         match data.next_as_str() {
-            Ok(value) => Ok(Ping::new(Some(value))),
-            Err(_) => Ok(Ping::default()),
+            Ok(value) => Ping::new(value),
+            Err(_) => Ping::default(),
         }
     }
 

--- a/cargo-projects/vivs/src/commands/set.rs
+++ b/cargo-projects/vivs/src/commands/set.rs
@@ -9,19 +9,17 @@ pub struct Set {
 }
 
 impl Set {
-    pub fn parse(mut data: DataChunkFrame) -> Result<Self> {
+    pub fn parse(mut data: DataChunkFrame) -> Self {
         // we try to get the key first
         let Ok(key) = data.next_as_str() else {
-            return Ok(Self::default());
+            return Self::default();
         };
         // and then the value
         let Ok(value) = data.next_as_str() else {
-            return Ok(Self::default());
+            return Self::default();
         };
-        Ok(Self {
-            key: Some(key),
-            value: Some(value),
-        })
+
+        Self { key, value }
     }
 
     pub async fn respond(&self, connection: &mut Connection, db: &DataStoreWrapper) -> Result<()> {

--- a/cargo-projects/vivs/src/data_chunk.rs
+++ b/cargo-projects/vivs/src/data_chunk.rs
@@ -63,6 +63,7 @@ pub struct DataChunkFrame {
     pub len: usize,
 }
 
+// The iterator should contain all the necessary commands and values e.g. [SET, key, value]
 impl DataChunkFrame {
     #[allow(clippy::should_implement_trait)]
     /// Tries to return the next element in the collection.
@@ -103,6 +104,7 @@ impl DataChunkFrame {
     }
 
     pub fn push_bulk_str(mut self, b: Bytes) -> Self {
+        // TODO
         // Hack (for now): convert iterator to vector
         // in order to push data chunks into it.
         // This functionality is part of the so called "client encoder"

--- a/cargo-projects/vivs/src/data_chunk.rs
+++ b/cargo-projects/vivs/src/data_chunk.rs
@@ -12,7 +12,7 @@ use std::{
 #[derive(Debug)]
 pub enum DataChunkError {
     Insufficient,
-    Uknown(String),
+    Unknown(String),
     Parse(String),
     NonExistent,
     Other(Utf8Error),
@@ -76,15 +76,15 @@ impl DataChunkFrame {
     /// Other an Error is returned.
     /// The reason the error is returned is because we attempt to convert a
     /// slice of bytes to string slice in the match expression
-    pub fn next_as_str(&mut self) -> Result<String, DataChunkError> {
+    pub fn next_as_str(&mut self) -> Result<Option<String>, DataChunkError> {
         let Some(segment) = self.segments.next() else {
-            return Err(DataChunkError::NonExistent);
+            return Ok(None);
         };
 
         match segment {
             DataChunk::Bulk(value) => {
                 let value = std::str::from_utf8(value.chunk())?;
-                Ok(value.to_owned())
+                Ok(Some(value.to_owned()))
             }
             _ => unimplemented!(),
         }
@@ -234,7 +234,7 @@ impl DataChunk {
 
 impl From<String> for DataChunkError {
     fn from(value: String) -> Self {
-        DataChunkError::Uknown(value)
+        DataChunkError::Unknown(value)
     }
 }
 
@@ -254,7 +254,7 @@ impl fmt::Display for DataChunkError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DataChunkError::Parse(e) => format!("protocol error: {:?}", e).fmt(f),
-            DataChunkError::Uknown(err) => err.fmt(f),
+            DataChunkError::Unknown(err) => err.fmt(f),
             DataChunkError::Insufficient => "error".fmt(f),
             DataChunkError::NonExistent => "no next value in the iterator".fmt(f),
             DataChunkError::Other(val) => val.fmt(f),

--- a/cargo-projects/vivs/src/listener.rs
+++ b/cargo-projects/vivs/src/listener.rs
@@ -7,6 +7,7 @@ pub struct Listener {
     pub db: DataStoreWrapper,
 }
 
+/// Constructs, listens to incoming connections and assembles their processing
 impl Listener {
     pub fn new(tcp_listener: TcpListener, db: DataStoreWrapper) -> Self {
         Listener { tcp_listener, db }
@@ -17,11 +18,11 @@ impl Listener {
         info!("Listening for connections");
 
         // To accept multiple incoming connections,
-        // loop construct is used here to handle each connection.
-        // as a separate task (either on the current or different thread)
-        // Then a loop inside each thread is used to handle incoming data from client socket
+        // a loop construct is used here to handle each connection.
+        // It is handled as a separate task (either on the current or different thread).
+        // Then a loop inside each thread is used to handle incoming data from the client socket.
         loop {
-            // wait to accept a new connection from the tcp listener
+            // waits to accept a new connection from the tcp listener
             let (tcp_stream, socket_addr) = self.tcp_listener.accept().await?;
 
             info!("Incoming connection request from {:?}", socket_addr);

--- a/cargo-projects/vivs/src/server.rs
+++ b/cargo-projects/vivs/src/server.rs
@@ -1,8 +1,7 @@
 use crate::DataStoreWrapper;
 use crate::Listener;
 use crate::Result;
-use log::error;
-use log::info;
+use log::{error, info};
 use tokio::net::TcpListener;
 
 pub async fn start(ipv4: String, port: String) -> Result<()> {
@@ -15,7 +14,6 @@ pub async fn start(ipv4: String, port: String) -> Result<()> {
         err
     })?;
 
-    // listener construct, listens to incoming connections and assembles their processing
     let listener = Listener {
         tcp_listener,
         db: DataStoreWrapper::new(),

--- a/cargo-projects/vivs/src/utils.rs
+++ b/cargo-projects/vivs/src/utils.rs
@@ -5,3 +5,7 @@ pub fn format_err_msg(str: String) -> String {
 pub fn num_args_err() -> &'static str {
     "Incorrect number of arguments\r\n"
 }
+
+pub fn unknown_cmd_err(value: String) -> String {
+    format!("Unknown command: {value}\r\n")
+}


### PR DESCRIPTION
- Commands were previously returning result types which were unnecessary, removed these
- Added new ParseCommand error type
- Fixed typos
